### PR TITLE
Load previous pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,14 @@ scrollable will default to using the window for the scroll binding.
 
 You can optionally pass an offset value.   This value will be used when calculating if the bottom of the scrollable has been reached.  
 
+* **loadPrevious**
+
+```hbs
+{{#infinity-loader loadPrevious=true}}
+```
+
+You can optionally pass a value for loadPrevious. Setting this to true will cause the infinity loader to load the previous page instead of the next.
+
 ### Use ember-infinity with button
 
 You can use the route loading magic of Ember Infinity without using the InfinityLoader component.

--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -13,6 +13,7 @@ const InfinityLoaderComponent = Ember.Component.extend({
   developmentMode: false,
   scrollable: null,
   triggerOffset: 0,
+  loadPrevious: false,
 
   didInsertElement() {
     this._super(...arguments);
@@ -55,17 +56,35 @@ const InfinityLoaderComponent = Ember.Component.extend({
     return this._selfOffset() - this.get('triggerOffset');
   },
 
+  _scrollableHeight() {
+    return this.get('_scrollable')[0].scrollHeight || document.documentElement.scrollHeight;
+  },
+
   _shouldLoadMore() {
     if (this.get('developmentMode') || this.isDestroying || this.isDestroyed) {
       return false;
     }
 
-    return this._bottomOfScrollableOffset() > this._triggerOffset();
+    var scrolledBelowTrigger = this._bottomOfScrollableOffset() > this._triggerOffset();
+
+    if (scrolledBelowTrigger && this.get('loadPrevious')) {
+      var scrollable = this.get('_scrollable'),
+          scrollableScrollTop = scrollable.scrollTop(),
+          scrollableHeight = scrollable.height(),
+          offsetTop = this._selfOffset();
+
+      return (
+        offsetTop > scrollableScrollTop &&
+        offsetTop < scrollableScrollTop + scrollableHeight
+      );
+    }
+
+    return scrolledBelowTrigger;
   },
 
   _loadMoreIfNeeded() {
     if (this._shouldLoadMore()) {
-      this.sendAction('loadMoreAction', this.get('infinityModel'));
+      this.sendAction('loadMoreAction', this.get('infinityModel'), this.get('loadPrevious'));
     }
   },
 
@@ -89,6 +108,13 @@ const InfinityLoaderComponent = Ember.Component.extend({
     }
   },
 
+  _updateScrollPosition(oldScrollableHeight) {
+    var scrollable = this.get('_scrollable'),
+        newScrollableHeight = this._scrollableHeight();
+
+    scrollable.scrollTop(scrollable.scrollTop() + (newScrollableHeight - oldScrollableHeight));
+  },
+
   loadedStatusDidChange: Ember.observer('infinityModel.reachedInfinity', 'destroyOnInfinity', function () {
     if (this.get('infinityModel.reachedInfinity') && this.get('destroyOnInfinity')) {
       this.destroy();
@@ -96,6 +122,14 @@ const InfinityLoaderComponent = Ember.Component.extend({
   }),
 
   infinityModelPushed: Ember.observer('infinityModel.length', function() {
+    if (this.get('loadPrevious')) {
+      var oldScrollableHeight = this._scrollableHeight();
+
+      Ember.run.scheduleOnce('afterRender', this, function() {
+        this._updateScrollPosition(oldScrollableHeight);
+      });
+    }
+
     Ember.run.scheduleOnce('afterRender', this, this._loadMoreIfNeeded);
   })
 });

--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -25,11 +25,18 @@ const RouteMixin = Ember.Mixin.create({
 
   /**
     @private
-    @property currentPage
+    @property firstPage
     @type Integer
     @default 0
   */
-  firstPage: Infinity,
+  firstPage: 0,
+
+  /**
+    @private
+    @property lastPage
+    @type Integer
+    @default 0
+  */
   lastPage: 0,
 
   /**
@@ -138,6 +145,12 @@ const RouteMixin = Ember.Mixin.create({
     return (totalPages && lastPage !== undefined) ? (lastPage < totalPages) : false;
   }),
 
+  /**
+    @private
+    @property _canLoadMorePrevious
+    @type Boolean
+    @default false
+  */
   _canLoadPrevious: Ember.computed('firstPage', function() {
     const firstPage = this.get('firstPage');
 

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -148,6 +148,46 @@ test('it allows customizations of meta parsing params', assert => {
   assert.equal(route.get('_totalPages'), 22, '_totalPages');
 });
 
+
+test("It loads previous page when loadPrevious parameter is set to true", function(assert) {
+  var store =  createMockStore(EO({
+      items: [
+        {id: 1, name: 'Test'},
+        {id: 2, name: 'Test 2'}
+      ],
+      unshiftObjects: Ember.K,
+      meta: {
+        total_pages: 2
+      }
+    }));
+
+  var route = createRoute(['item', { startingPage: 2, perPage: 1 }],
+    { store: store }
+  );
+
+  callModelHook(route);
+
+  var loadMore = (loadPrevious) => {
+    Ember.run(() => {
+      route._infinityLoad(loadPrevious);
+    });
+  };
+
+  assert.expect(6);
+
+  loadMore();
+
+  assert.ok(route.get('_canLoadPrevious'), 'can load previous');
+  assert.equal(route.get('firstPage'), 2, 'firstPage');
+  assert.equal(route.get('lastPage'), 2, 'lastPage');
+
+  loadMore(true);
+
+  assert.notOk(route.get('_canLoadPrevious'), 'can load previous');
+  assert.equal(route.get('firstPage'), 1, 'firstPage');
+  assert.equal(route.get('lastPage'), 2, 'lastPage');
+});
+
 module('RouteMixin - reaching the end', {
   setup() {
     this.store = createMockStore(EO({

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -108,7 +108,7 @@ test('it sets state before it reaches the end', assert => {
   var model = callModelHook(route);
 
   assert.equal(route.get('_totalPages'), 31, '_totalPages');
-  assert.equal(route.get('currentPage'), 1, 'currentPage');
+  assert.equal(route.get('lastPage'), 1, 'lastPage');
   assert.equal(route.get('_canLoadMore'), true, '_canLoadMore');
   assert.ok(Ember.$.isEmptyObject(route.get('_extraParams')), 'extra params are empty');
   assert.ok(!model.get('reachedInfinity'), 'Should not reach infinity');
@@ -184,7 +184,7 @@ test('it sets state when it reaches the end', function (assert) {
   this.createRoute({ startingPage: 2 });
 
   assert.equal(this.route.get('_totalPages'), 2, '_totalPages');
-  assert.equal(this.route.get('currentPage'), 2, 'currentPage');
+  assert.equal(this.route.get('lastPage'), 2, 'lastPage');
   assert.equal(this.route.get('_canLoadMore'), false, '_canLoadMore');
   assert.ok(Ember.$.isEmptyObject(this.route.get('_extraParams')), '_extraParams');
   assert.ok(this.model.get('reachedInfinity'), 'Should reach infinity');
@@ -202,7 +202,7 @@ test('it uses extra params when loading more data', function (assert) {
 
   assert.equal(this.route.get('_extraParams.extra'), 'param', '_extraParams.extra');
   assert.equal(this.route.get('_canLoadMore'), false, '_canLoadMore');
-  assert.equal(this.route.get('currentPage'), 2, 'currentPage');
+  assert.equal(this.route.get('lastPage'), 2, 'lastPage');
   assert.ok(this.model.get('reachedInfinity'), 'Should reach infinity');
 });
 
@@ -212,17 +212,17 @@ test("It doesn't request more pages once _canLoadMore is false", function (asser
   this.createRoute();
 
   assert.ok(this.route.get('_canLoadMore'), 'can load more');
-  assert.equal(this.route.get('currentPage'), 1, 'currentPage');
+  assert.equal(this.route.get('lastPage'), 1, 'lastPage');
 
   this.loadMore();
 
   assert.notOk(this.route.get('_canLoadMore'), 'can load more');
-  assert.equal(this.route.get('currentPage'), 2, 'currentPage');
+  assert.equal(this.route.get('lastPage'), 2, 'lastPage');
 
   this.loadMore();
 
   assert.notOk(this.route.get('_canLoadMore'), 'can load more');
-  assert.equal(this.route.get('currentPage'), 2, 'currentPage');
+  assert.equal(this.route.get('lastPage'), 2, 'lastPage');
 });
 
 test("It resets the currentPage when the model hook is called again", function (assert) {
@@ -231,18 +231,18 @@ test("It resets the currentPage when the model hook is called again", function (
   this.createRoute();
 
   assert.ok(this.route.get('_canLoadMore'), 'can load more');
-  assert.equal(this.route.get('currentPage'), 1, 'currentPage');
+  assert.equal(this.route.get('lastPage'), 1, 'lastPage');
 
   this.callModelHook();
-  assert.equal(this.route.get('currentPage'), 1, 'currentPage');
+  assert.equal(this.route.get('lastPage'), 1, 'lastPage');
 
   this.loadMore();
 
-  assert.equal(this.route.get('currentPage'), 2, 'currentPage');
+  assert.equal(this.route.get('lastPage'), 2, 'lastPage');
 
   this.callModelHook();
 
-  assert.equal(this.route.get('currentPage'), 1, 'currentPage');
+  assert.equal(this.route.get('lastPage'), 1, 'lastPage');
 });
 
 module('RouteMixin - loading more data', {
@@ -279,7 +279,7 @@ test('it uses overridden params when loading more data', function (assert) {
   this.expectedPageNumber = 2;
 
   assert.equal(this.route.get('_canLoadMore'), true, '_canLoadMore');
-  assert.equal(this.route.get('currentPage'), 2, 'currentPage');
+  assert.equal(this.route.get('lastPage'), 2, 'lastPage');
 });
 
 test('it uses overridden params when reaching the end', function (assert) {
@@ -292,7 +292,7 @@ test('it uses overridden params when reaching the end', function (assert) {
   });
 
   assert.equal(this.route.get('_canLoadMore'), false, '_canLoadMore');
-  assert.equal(this.route.get('currentPage'), 3, 'currentPage');
+  assert.equal(this.route.get('lastPage'), 3, 'lastPage');
   assert.ok(this.model.get('reachedInfinity'), 'Should reach infinity');
 });
 
@@ -354,7 +354,7 @@ test('it uses bound params when reaching the end', function (assert) {
   this.loadMore();
 
   assert.equal(this.route.get('_canLoadMore'), false, '_canLoadMore');
-  assert.equal(this.route.get('currentPage'), 3, 'currentPage');
+  assert.equal(this.route.get('lastPage'), 3, 'lastPage');
   assert.ok(this.model.get('reachedInfinity'), 'Should reach infinity');
 });
 
@@ -453,7 +453,7 @@ test('It allows to set startingPage as 0', assert => {
 
   callModelHook(route);
 
-  assert.equal(0, route.get('currentPage'));
+  assert.equal(0, route.get('lastPage'));
   assert.equal(true, route.get('_canLoadMore'));
 });
 


### PR DESCRIPTION
Adds the ability to load previous pages. For example, if the starting page was 3, this allows you to create an infinity loader component that would load page 2, etc.

The purpose of this was to make the infinite scroll list more SEO-friendly ([reference](https://webmasters.googleblog.com/2014/02/infinite-scroll-search-friendly.html)) by allowing each individual page to be accessed by query parameters and allowing previous pages to be loaded if the user doesn't start on the first page.
