### PR TITLE
Fix custom infinity model check

### DIFF
--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -112,7 +112,7 @@ const RouteMixin = Mixin.create({
 
     let boundParams, ExtendedInfinityModel;
     if (typeOf(boundParamsOrInfinityModel) === "class") {
-      if (!(boundParamsOrInfinityModel instanceof InfinityModel)) {
+      if (!(boundParamsOrInfinityModel.prototype instanceof InfinityModel)) {
         throw new EmberError("Ember Infinity: You must pass an Infinity Model instance as the third argument");
       }
       ExtendedInfinityModel = boundParamsOrInfinityModel;

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -275,8 +275,8 @@ module('RouteMixin', function() {
     hooks.beforeEach(function() {
       this.store = createMockStore(EA([{id: 1, name: 'Test'}], { meta: { total_pages: 2 } }));
 
-      this.createRoute = (extras, boundParams) => {
-        this.route = createRoute(['item', extras, boundParams],
+      this.createRoute = (extras, boundParamsOrInfinityModel) => {
+        this.route = createRoute(['item', extras, boundParamsOrInfinityModel],
           { store: this.store }
         );
 
@@ -346,7 +346,6 @@ module('RouteMixin', function() {
           return params;
         }
       });
-      ExtendedInfinityModel = ExtendedInfinityModel.create();
       this.createRoute({ extra: 'param' }, ExtendedInfinityModel);
 
       assert.equal(this.model instanceof InfinityModel, true, 'model is instance of extended infinity model');


### PR DESCRIPTION
Our test suite previously assumed a custom infinity model would be created when passed to `this.infinityModel`.  However, this isn't correct as it isn't comparing the prototype chain.

Close #253 