### PR TITLE
Use released ember-in-viewport

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
-    "ember-in-viewport": "DockYard/ember-in-viewport"
+    "ember-in-viewport": "^3.1.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2384,9 +2384,9 @@ ember-get-config@^0.2.2:
     broccoli-file-creator "^1.1.1"
     ember-cli-babel "^6.3.0"
 
-ember-in-viewport@DockYard/ember-in-viewport:
-  version "3.1.0"
-  resolved "https://codeload.github.com/DockYard/ember-in-viewport/tar.gz/5fef66698dc8a260e2b479049696376dd31da7d9"
+ember-in-viewport@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/ember-in-viewport/-/ember-in-viewport-3.1.1.tgz#76ef19bc91b125775d0887854acfa4b10ee32e9d"
   dependencies:
     ember-cli-babel "^6.14.1"
 


### PR DESCRIPTION
Was encountering timeouts in CI when using the DockYard/ember-in-viewport _version_

Instead I've set the version to the latest release to get it from the yarn registry.