### PR TITLE
Fix infinity model container so services can be injected on it

### DIFF
--- a/addon/services/infinity.js
+++ b/addon/services/infinity.js
@@ -2,6 +2,7 @@ import Service from '@ember/service';
 import InfinityModel from 'ember-infinity/lib/infinity-model';
 import InfinityPromiseArray from 'ember-infinity/lib/infinity-promise-array';
 import EmberError from '@ember/error';
+import { getOwner } from '@ember/application';
 import { A } from '@ember/array';
 import { isEmpty, typeOf } from '@ember/utils';
 import { scheduleOnce } from '@ember/runloop';
@@ -227,6 +228,7 @@ export default Service.extend({
     }
 
     let initParams = {
+      container: getOwner(this),
       currentPage,
       firstPage,
       perPage,
@@ -413,7 +415,7 @@ export default Service.extend({
     @param {EmberInfinity.InfinityModel} infinityModel
    */
   _notifyInfinityModelUpdated(queryObject, infinityModel) {
-    const totalPages = get(this, '_totalPages');
+    const totalPages = get(infinityModel, '_totalPages');
     const lastPageLoaded = get(infinityModel, 'currentPage');
     scheduleOnce('afterRender', infinityModel, 'infinityModelUpdated', { lastPageLoaded, totalPages, queryObject });
   },

--- a/tests/acceptance/infinity-route-test.js
+++ b/tests/acceptance/infinity-route-test.js
@@ -66,6 +66,9 @@ module('Acceptance: Infinity Route - infinity routes', function(hooks) {
 
     shouldBeItemsOnTheList(assert, 50);
     infinityShouldBeReached(assert);
+
+    const global = this.owner.lookup('service:global');
+    assert.equal(global.isUpdated, true);
   });
 
   test('it should start loading more items before the scroll is on the very bottom ' +

--- a/tests/dummy/app/routes/test-scrollable.js
+++ b/tests/dummy/app/routes/test-scrollable.js
@@ -1,11 +1,23 @@
 import Route from '@ember/routing/route';
-import { get } from '@ember/object';
+import InfinityModel from 'ember-infinity/lib/infinity-model';
+import { get, set } from '@ember/object';
 import { inject as service } from '@ember/service';
+
+const ExtendedInfinityModel =  InfinityModel.extend({
+  global: service(),
+  infinityModelUpdated() {
+    set(get(this, 'global'), 'isUpdated', true);
+  }
+});
 
 export default Route.extend({
   infinity: service(),
 
   model({ page, perPage }) {
-    return get(this, 'infinity').model('post', { startingPage: page, perPage });
+    return get(this, 'infinity').model(
+      'post',
+      { startingPage: page, perPage },
+      ExtendedInfinityModel
+    );
   }
 });

--- a/tests/dummy/app/services/global.js
+++ b/tests/dummy/app/services/global.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
 
 export default Service.extend({
-  categoryId: '1'
+  categoryId: '1',
+  isUpdated: false
 });


### PR DESCRIPTION
Injecting services on the extended infinity model was failing because the instance is created without a container. This seems like the right fix?

With the 1.0 API changes, _infinityModelLoaded_ and _infinityModelUpdated_ no longer have the context they did as members of the route. Now, an intermediary (e.g. a service) appears to be required to effect a change in the context of the route or controller, e.g.:

```js
import InfinityModel from 'ember-infinity/lib/infinity-model';

export default InfinityModel.extend({
  infinityModelUpdated({ lastPageLoaded, totalPages }) {
    if (totalPages > lastPageLoaded) {
      // Hide footer until all records are loaded
      set(this, 'memoryStorage.hasActiveInfiniteScroll', true);
    }
  }
});
```

```hbs
{{! app/templates/application.hbs}}
{{#unless memoryStorage.hasActiveInfiniteScroll}}
  {{footer-stuff}}
{{/unless}}
```