### PR TITLE
Skip `_checkScrollableHeight` on destroyed element

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -249,6 +249,9 @@ const InfinityLoaderComponent = Component.extend(InViewportMixin, {
    * @method _checkScrollableHeight
    */
   _checkScrollableHeight() {
+    if (this.isDestroying || this.isDestroyed) {
+      return false;
+    }
     if (this._viewportHeight() > this.element.offsetTop) {
       // load again
       this._debounceScrolledToBottom();


### PR DESCRIPTION
If the component was destroyed, but the callback was executed, it triggered an exception because `this.element` was not available.