### PR TITLE
Migrate away from deprecated `isVisible`

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -71,11 +71,11 @@ const InfinityLoaderComponent = Component.extend(InViewportMixin, {
    */
   triggerOffset: 0,
   /**
-   * https://emberjs.com/api/ember/3.0/classes/Component/properties/isVisible?anchor=isVisible
+   * whether the loader is showing or not
    *
-   * @property isVisible
+   * @property isShowing
    */
-  isVisible: true,
+  isShowing: true,
 
   init() {
     this._super(...arguments);
@@ -170,7 +170,7 @@ const InfinityLoaderComponent = Component.extend(InViewportMixin, {
         set(infinityModel, '_scrollable', get(this, 'scrollable'));
         set(this, 'isDoneLoading', false);
         if (!get(this, 'hideOnInfinity')) {
-          set(this, 'isVisible', true);
+          set(this, 'isShowing', true);
         }
       });
   },
@@ -185,10 +185,10 @@ const InfinityLoaderComponent = Component.extend(InViewportMixin, {
           set(this, 'isDoneLoading', true);
 
           if (get(this, 'hideOnInfinity')) {
-            set(this, 'isVisible', false);
+            set(this, 'isShowing', false);
           }
         } else {
-          set(this, 'isVisible', true);
+          set(this, 'isShowing', true);
         }
       });
   },

--- a/app/templates/components/infinity-loader.hbs
+++ b/app/templates/components/infinity-loader.hbs
@@ -1,9 +1,11 @@
-{{#if hasBlock}}
-  {{yield infinityModelContent}}
-{{else}}
-  {{#if isDoneLoading}}
-    <span>{{loadedText}}</span>
+{{#if isShowing}}
+  {{#if hasBlock}}
+    {{yield infinityModelContent}}
   {{else}}
-    <span>{{loadingText}}</span>
+    {{#if isDoneLoading}}
+      <span>{{loadedText}}</span>
+    {{else}}
+      <span>{{loadingText}}</span>
+    {{/if}}
   {{/if}}
 {{/if}}

--- a/tests/integration/infinity-loader-test.js
+++ b/tests/integration/infinity-loader-test.js
@@ -49,7 +49,7 @@ module('infinity-loader', function(hooks) {
       hideOnInfinity=true
       infinity=infinityServiceMock
       _checkScrollableHeight=_checkScrollableHeight}}`);
-    assert.equal(this.element.querySelector('.infinity-loader').style.display, 'none', 'Element is hidden');
+    assert.notOk(this.element.querySelector('.infinity-loader'), 'Element is hidden');
   });
 
   test('hideOnInfinity does not work if hideOnInfinity=false', async function(assert) {


### PR DESCRIPTION
Migrate away from deprecated `isVisible` and instead conditionally show loader when `isShowing` is true