### PR TITLE
Bump node in pkg.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:all": "ember try:each"
   },
   "engines": {
-    "node": "10.* || 11.* || >= 12.*"
+    "node": "10.* || >= 12.*"
   },
   "dependencies": {
     "ember-cli-babel": "~7.11.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:all": "ember try:each"
   },
   "engines": {
-    "node": "10.* || >= 12.*"
+    "node": "10.* || 11.* || >= 12.*"
   },
   "dependencies": {
     "ember-cli-babel": "~7.11.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:all": "ember try:each"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": "10.* || >= 12.*"
   },
   "dependencies": {
     "ember-cli-babel": "~7.11.0",


### PR DESCRIPTION
10 or > 12

8 is EOL.  Should have done this in the 2.0 release #401 