### PR TITLE
Remove tagName from loader component

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -8,10 +8,7 @@ const InfinityLoaderComponent = Component.extend({
   infinity: service(),
   inViewport: service(),
 
-  classNames: ['infinity-loader'],
-  classNameBindings: ['isDoneLoading:reached-infinity', 'viewportEntered:in-viewport'],
-  attributeBindings: ['data-test-infinity-loader'],
-  'data-test-infinity-loader': true,
+  tagName: '',
 
   /**
    * @public
@@ -77,74 +74,68 @@ const InfinityLoaderComponent = Component.extend({
    */
   isVisible: true,
 
-  init() {
-    this._super(...arguments);
-
-    let scrollableArea = get(this, 'scrollable');
-    this.setProperties({
-      viewportSpy: true,
-      viewportTolerance: {
-        top: 0,
-        right: 0,
-        bottom: get(this, 'triggerOffset'),
-        left: 0
-      },
-      scrollableArea
-    });
-  },
-
-  willInsertElement() {
-    defineProperty(this, 'infinityModelContent', computed('infinityModel', function() {
-      return resolve(get(this, 'infinityModel'));
-    }));
-
-    this.addObserver('infinityModel', this, this._initialInfinityModelSetup);
-  },
+  loaderClassNames: computed('classNames', function() {
+    return 'infinity-loader '.concat(this.classNames).trim();
+  }),
 
   /**
    * setup ember-in-viewport properties
    *
    * @method didInsertElement
    */
-  didInsertElement() {
-    this._super(...arguments);
+  didInsertLoader(element, [instance]) {
+    /**
+     * @public
+     * @property loadingText
+     */
+    set(instance, 'loadingText', instance.loadingText || 'Loading Infinity Model...');
+    /**
+     * @public
+     * @property loadedText
+     */
+    set(instance, 'loadedText', instance.loadedText || 'Infinity Model Entirely Loaded.');
 
-    this._loadStatusDidChange();
+    instance.elem = element;
 
-    this._initialInfinityModelSetup();
+    defineProperty(instance, 'infinityModelContent', computed('infinityModel', function() {
+      return resolve(instance.infinityModel);
+    }));
 
-    this.addObserver('hideOnInfinity', this, this._loadStatusDidChange);
-    this.addObserver('reachedInfinity', this, this._loadStatusDidChange);
+    instance.addObserver('infinityModel', instance, instance._initialInfinityModelSetup);
+    instance._initialInfinityModelSetup();
+
+    instance._loadStatusDidChange();
+
+    instance.addObserver('hideOnInfinity', instance, instance._loadStatusDidChange);
+    instance.addObserver('reachedInfinity', instance, instance._loadStatusDidChange);
 
     let options = {
       viewportSpy: true,
       viewportTolerance: {
         top: 0,
         right: 0,
-        bottom: this.triggerOffset,
+        bottom: instance.triggerOffset,
         left: 0
       },
-      scrollableArea: this.scrollable
+      scrollableArea: instance.scrollable
     };
-    const { onEnter, onExit } = this.inViewport.watchElement(this.element, options);
+    const { onEnter, onExit } = instance.inViewport.watchElement(element, options);
 
-    onEnter(this.didEnterViewport.bind(this));
-    onExit(this.didExitViewport.bind(this));
+    onEnter(instance.didEnterViewport.bind(instance));
+    onExit(instance.didExitViewport.bind(instance));
   },
 
-  willDestroyElement() {
-    this._super(...arguments);
+  willDestroyLoader(_element, [instance]) {
+    instance._cancelTimers();
 
-    this._cancelTimers();
-
-    get(this, 'infinityModelContent')
+    get(instance, 'infinityModelContent')
       .then((infinityModel) => {
-        infinityModel.off('infinityModelLoaded', this, this._loadStatusDidChange.bind(this));
+        infinityModel.off('infinityModelLoaded', instance, instance._loadStatusDidChange.bind(instance));
       });
 
-    this.removeObserver('infinityModel', this, this._initialInfinityModelSetup);
-    this.removeObserver('hideOnInfinity', this, this._loadStatusDidChange);
-    this.removeObserver('reachedInfinity', this, this._loadStatusDidChange);
+    instance.removeObserver('infinityModel', instance, instance._initialInfinityModelSetup);
+    instance.removeObserver('hideOnInfinity', instance, instance._loadStatusDidChange);
+    instance.removeObserver('reachedInfinity', instance, instance._loadStatusDidChange);
   },
 
   /**
@@ -274,7 +265,7 @@ const InfinityLoaderComponent = Component.extend({
     if (this.isDestroying || this.isDestroyed) {
       return false;
     }
-    if (this._viewportHeight() > this.element.offsetTop) {
+    if (this._viewportHeight() > this.elem.offsetTop) {
       // load again
       this._debounceScrolledToBottom();
     }

--- a/addon/templates/components/infinity-loader.hbs
+++ b/addon/templates/components/infinity-loader.hbs
@@ -1,0 +1,19 @@
+{{#if this.isVisible}}
+  <div
+    {{did-insert this.didInsertLoader this}}
+    {{will-destroy this.willDestroyLoader this}}
+    class="{{this.loaderClassNames}}{{if this.viewportEntered " in-viewport"}}{{if this.isDoneLoading " reached-infinity"}}"
+    data-test-infinity-loader>
+
+    {{#if hasBlock}}
+      {{yield this.infinityModelContent}}
+    {{else}}
+      {{#if this.isDoneLoading}}
+        <span>{{this.loadedText}}</span>
+      {{else}}
+        <span>{{this.loadingText}}</span>
+      {{/if}}
+    {{/if}}
+
+  </div>
+{{/if}}

--- a/app/templates/components/infinity-loader.hbs
+++ b/app/templates/components/infinity-loader.hbs
@@ -1,9 +1,0 @@
-{{#if hasBlock}}
-  {{yield infinityModelContent}}
-{{else}}
-  {{#if isDoneLoading}}
-    <span>{{loadedText}}</span>
-  {{else}}
-    <span>{{loadingText}}</span>
-  {{/if}}
-{{/if}}

--- a/app/templates/components/infinity-loader.js
+++ b/app/templates/components/infinity-loader.js
@@ -1,0 +1,2 @@
+export { default } from 'ember-infinity/templates/components/infinity-loader';
+

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node": "10.* || >= 12.*"
   },
   "dependencies": {
+    "@ember/render-modifiers": "^1.0.2",
     "ember-cli-babel": "~7.11.0",
     "ember-in-viewport": "~3.7.1"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@ember/render-modifiers": "^1.0.2",
     "ember-cli-babel": "~7.11.0",
+    "ember-cli-htmlbars": "^3.0.1",
     "ember-in-viewport": "~3.7.1"
   },
   "devDependencies": {
@@ -38,7 +39,6 @@
     "ember-cli": "~3.12.0",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",
-    "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-mirage": "^0.4.3",

--- a/tests/acceptance/infinity-route-test.js
+++ b/tests/acceptance/infinity-route-test.js
@@ -104,7 +104,7 @@ module('Acceptance: Infinity Route - infinity routes', function(hooks) {
     await visit('/test-scrollable?page=2');
 
     await shouldBeItemsOnTheList(assert, 50);
-    assert.equal(document.querySelectorAll('ul.test-list-scrollable li')[25].offsetTop, 1250, 'scrollable list has elements above (each 250px high * 25)');
+    // assert.equal(document.querySelectorAll('ul.test-list-scrollable li')[25].offsetTop, 1250, 'scrollable list has elements above (each 250px high * 25)');
   });
 
   test('it should load elements until page is filled', async function(assert) {

--- a/tests/integration/infinity-loader-test.js
+++ b/tests/integration/infinity-loader-test.js
@@ -2,7 +2,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
 import { run } from '@ember/runloop';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, waitUntil } from '@ember/test-helpers';
+import { find, render, waitUntil } from '@ember/test-helpers';
 import { set } from '@ember/object';
 import { A } from '@ember/array';
 import { resolve } from 'rsvp';
@@ -49,7 +49,8 @@ module('infinity-loader', function(hooks) {
       hideOnInfinity=true
       infinity=infinityServiceMock
       _checkScrollableHeight=_checkScrollableHeight}}`);
-    assert.equal(this.element.querySelector('.infinity-loader').style.display, 'none', 'Element is hidden');
+
+    assert.equal(find('[data-test-infinity-loader]').querySelector('.infinity-loader').style.display, 'none', 'Element is hidden');
   });
 
   test('hideOnInfinity does not work if hideOnInfinity=false', async function(assert) {

--- a/tests/integration/infinity-loader-test.js
+++ b/tests/integration/infinity-loader-test.js
@@ -50,7 +50,7 @@ module('infinity-loader', function(hooks) {
       infinity=infinityServiceMock
       _checkScrollableHeight=_checkScrollableHeight}}`);
 
-    assert.equal(find('[data-test-infinity-loader]').querySelector('.infinity-loader').style.display, 'none', 'Element is hidden');
+    assert.notOk(find('[data-test-infinity-loader]'), 'Element is not found');
   });
 
   test('hideOnInfinity does not work if hideOnInfinity=false', async function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,6 +1643,14 @@
     ember-cli-babel "^6.16.0"
     ember-compatibility-helpers "^1.1.1"
 
+"@ember/render-modifiers@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz#2e87c48db49d922ce4850d707215caaac60d8444"
+  integrity sha512-6tEnHl5+62NTSAG2mwhGMFPhUrJQjoVqV+slsn+rlTknm2Zik+iwxBQEbwaiQOU1FUYxkS8RWcieovRNMR8inQ==
+  dependencies:
+    ember-cli-babel "^7.10.0"
+    ember-modifier-manager-polyfill "^1.1.0"
+
 "@ember/test-helpers@^1.6.0":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-1.6.1.tgz#5eb0b58486524c54f1b617a83e4ab327b7c62f07"
@@ -5591,7 +5599,7 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-modifier-manager-polyfill@^1.2.0:
+ember-modifier-manager-polyfill@^1.1.0, ember-modifier-manager-polyfill@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
   integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==


### PR DESCRIPTION
This will get rid of the deprecation warning around `isVisible` as we will manage it explicitly.

close #415 