### PR TITLE
Component already exists Error

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -2,8 +2,11 @@ import { run } from '@ember/runloop';
 import { get, set, computed, defineProperty } from '@ember/object';
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
+import layout from '../templates/components/infinity-loader';
 
 const InfinityLoaderComponent = Component.extend({
+  layout,
+
   infinity: service(),
   inViewport: service(),
 

--- a/app/components/infinity-loader.js
+++ b/app/components/infinity-loader.js
@@ -1,3 +1,3 @@
-import infinityLoader from 'ember-infinity/components/infinity-loader';
+import InfinityLoader from 'ember-infinity/components/infinity-loader';
 
-export default infinityLoader;
+export default InfinityLoader;

--- a/app/templates/components/infinity-loader.js
+++ b/app/templates/components/infinity-loader.js
@@ -1,2 +1,0 @@
-export { default } from 'ember-infinity/templates/components/infinity-loader';
-


### PR DESCRIPTION
Introducing a templated infinity-loader broke this. 

As an alternative, you can rename your custom template from `infinity-loader` to whatever.  In your component.js, you will have to extend ember-infinity's `infinity-loader`

```js
import InfinityLoader from 'ember-infinity/components/infinity-loader';

export default class MyLoader extends InfinityLoader();
```

close #417