### PR TITLE
Fix error when loader is destroyed before model loads.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-cli-template-lint": "^1.0.0-beta.1",
     "ember-cli-test-loader": "^2.2.0",
     "ember-cli-uglify": "^2.1.0",
+    "ember-concurrency": "^1.1.7",
     "ember-data": "~3.12.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",

--- a/tests/integration/infinity-loader-test.js
+++ b/tests/integration/infinity-loader-test.js
@@ -2,7 +2,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
 import { run } from '@ember/runloop';
 import { setupRenderingTest } from 'ember-qunit';
-import { find, render, waitUntil } from '@ember/test-helpers';
+import { find, render, waitUntil, clearRender } from '@ember/test-helpers';
 import { set } from '@ember/object';
 import { A } from '@ember/array';
 import { resolve } from 'rsvp';
@@ -82,5 +82,25 @@ module('infinity-loader', function(hooks) {
                 {{/infinity-loader}}
                 `);
     assert.equal(this.element.querySelector('.infinity-loader > span').textContent, "My custom block");
+  });
+
+  test('it gracefully handles removal before model loads', async function(assert) {
+    assert.expect(0);
+
+    this.set('showLoader', true);
+
+    const model = this.infinityModel;
+    // using runloop.later does not work here…
+    this.set('infinityModel', new Promise(resolve =>
+      setTimeout(() => resolve(model), 1000)
+    ));
+
+    await render(hbs`
+      {{#if this.showLoader}}
+        {{infinity-loader infinityModel=infinityModel infinity=infinityServiceMock _checkScrollableHeight=_checkScrollableHeight}}
+      {{/if}}
+    `);
+
+    await clearRender();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5488,6 +5488,15 @@ ember-compatibility-helpers@^1.2.0:
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
+ember-concurrency@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-1.1.7.tgz#b3f0c0478db1096503499d39e1b263c575cd52ef"
+  integrity sha512-PtEJvB4wG8e5CEHRC9ILl2BxF6U/xlMOhfCji/x7FxNFB9M230Du86LAy+4/yOozZHyoARVuazABPUj02P+DmQ==
+  dependencies:
+    ember-cli-babel "^7.7.3"
+    ember-compatibility-helpers "^1.2.0"
+    ember-maybe-import-regenerator "^0.1.6"
+
 ember-data@~3.12.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.12.0.tgz#ce20c41163ce50124d12a4370641fd9b4a21c3e2"


### PR DESCRIPTION
Use `ember-concurrency` to handle cancellation of async work, in order to
avoid `set` being called on destroyed component (setting `isDoneLoading`)
when loader component is removed before model promise resolves.

Should also circumvents potential similar errors in other stages of loading.