### PR TITLE
Fix reuse of infinity-loader

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -106,8 +106,6 @@ const InfinityLoaderComponent = Component.extend({
     instance.addObserver('infinityModel', instance, instance._initialInfinityModelSetup);
     instance._initialInfinityModelSetup();
 
-    instance._loadStatusDidChange();
-
     instance.addObserver('hideOnInfinity', instance, instance._loadStatusDidChange);
     instance.addObserver('reachedInfinity', instance, instance._loadStatusDidChange);
 
@@ -186,6 +184,7 @@ const InfinityLoaderComponent = Component.extend({
         if (!get(this, 'hideOnInfinity')) {
           set(this, 'isVisible', true);
         }
+        this._loadStatusDidChange();
       });
   },
 

--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -80,6 +80,20 @@ const InfinityLoaderComponent = Component.extend({
     return 'infinity-loader '.concat(this.classNames).trim();
   }),
 
+  init() {
+    this._super(...arguments);
+
+    defineProperty(this, 'infinityModelContent', computed('infinityModel', function() {
+      return Promise.resolve(this.infinityModel);
+    }));
+
+    this.addObserver('infinityModel', this, this._initialInfinityModelSetup);
+    this._initialInfinityModelSetup();
+
+    this.addObserver('hideOnInfinity', this, this._loadStatusDidChange);
+    this.addObserver('reachedInfinity', this, this._loadStatusDidChange);
+  },
+
   /**
    * setup ember-in-viewport properties
    *
@@ -99,16 +113,6 @@ const InfinityLoaderComponent = Component.extend({
 
     instance.elem = element;
 
-    defineProperty(instance, 'infinityModelContent', computed('infinityModel', function() {
-      return Promise.resolve(instance.infinityModel);
-    }));
-
-    instance.addObserver('infinityModel', instance, instance._initialInfinityModelSetup);
-    instance._initialInfinityModelSetup();
-
-    instance.addObserver('hideOnInfinity', instance, instance._loadStatusDidChange);
-    instance.addObserver('reachedInfinity', instance, instance._loadStatusDidChange);
-
     let options = {
       viewportSpy: true,
       viewportTolerance: {
@@ -125,17 +129,17 @@ const InfinityLoaderComponent = Component.extend({
     onExit(instance.didExitViewport.bind(instance));
   },
 
-  willDestroyLoader(_element, [instance]) {
-    instance._cancelTimers();
+  willDestroy() {
+    this._cancelTimers();
 
-    get(instance, 'infinityModelContent')
+    get(this, 'infinityModelContent')
       .then((infinityModel) => {
-        infinityModel.off('infinityModelLoaded', instance, instance._loadStatusDidChange.bind(instance));
+        infinityModel.off('infinityModelLoaded', this, this._loadStatusDidChange.bind(this));
       });
 
-    instance.removeObserver('infinityModel', instance, instance._initialInfinityModelSetup);
-    instance.removeObserver('hideOnInfinity', instance, instance._loadStatusDidChange);
-    instance.removeObserver('reachedInfinity', instance, instance._loadStatusDidChange);
+    this.removeObserver('infinityModel', this, this._initialInfinityModelSetup);
+    this.removeObserver('hideOnInfinity', this, this._loadStatusDidChange);
+    this.removeObserver('reachedInfinity', this, this._loadStatusDidChange);
   },
 
   /**

--- a/addon/templates/components/infinity-loader.hbs
+++ b/addon/templates/components/infinity-loader.hbs
@@ -1,7 +1,6 @@
 {{#if this.isVisible}}
   <div
     {{did-insert this.didInsertLoader this}}
-    {{will-destroy this.willDestroyLoader this}}
     class="{{this.loaderClassNames}}{{if this.viewportEntered " in-viewport"}}{{if this.isDoneLoading " reached-infinity"}}"
     data-test-infinity-loader>
 


### PR DESCRIPTION
So after the refactor to remove `Component#isVisible` usage in https://github.com/ember-infinity/ember-infinity/pull/416 (which was in response to my own issue, so I feel partially responsible), the handling of the `infinityModel` being changed seems to have been broken.

Our use case is paginated search results, so we debounce creating a new infinity model when the user types something.

The first bug was that `_loadStatusDidChange` needed to be called initially for each model change, not just the first, or it could just sit visible on the page saying "Loading..." even if the new model only had one page.

The second bug was that the `_initialInfinityModelSetup` observer was cleared when the element was destroyed, which happens when the component hides itself once reaching infinity. I've moved this cleanup to the component level instead of tying it to the element.