### PR TITLE
Use abs position when checking if element is visible in viewport

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -278,7 +278,7 @@ const InfinityLoaderComponent = Component.extend({
     if (this.isDestroying || this.isDestroyed) {
       return false;
     }
-    if (this._viewportHeight() > this.elem.offsetTop) {
+    if (this._viewportBottom() > this.elem.getBoundingClientRect().top) {
       // load again
       this._debounceScrolledToBottom();
     }
@@ -292,17 +292,17 @@ const InfinityLoaderComponent = Component.extend({
   },
 
   /**
-    calculate the height of the viewport
+    calculate the bottom of the viewport
 
     @private
-    @method _viewportHeight
+    @method _viewportBottom
     @return Integer
    */
-  _viewportHeight() {
+  _viewportBottom() {
     if (typeof FastBoot === 'undefined') {
       let isScrollable = !!this.scrollable;
       let viewportElem = isScrollable ? document.querySelector(this.scrollable) : window;
-      return isScrollable ? viewportElem.clientHeight : viewportElem.innerHeight;
+      return isScrollable ? viewportElem.getBoundingClientRect().bottom : viewportElem.innerHeight;
     }
   }
 });


### PR DESCRIPTION
While implementing ember-infinity in my project I noticed that the `<InfinityLoader>` would be in view but would not load new records. One simple way of testing this was to have an endpoint that returns 1 record per page. ember-infinity loads the first page, `<InfinityLoader>` remains in view, and no new records are loaded.

This PR contains the fix I came up with which resolve the issue.

`clientHeight` doesn't tell us anything about where the `viewPortElem` is located in the window relative to where `this.elem` is located. Using absolute values ensures that `_debounceScrolledToBottom()` is always called when the `<InfinityLoader>` component is in view.