### PR TITLE
Fix isVisible deprecation

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -70,11 +70,11 @@ const InfinityLoaderComponent = Component.extend({
    */
   triggerOffset: 0,
   /**
-   * https://emberjs.com/api/ember/3.0/classes/Component/properties/isVisible?anchor=isVisible
+   * flag to show/hide the component
    *
-   * @property isVisible
+   * @property shouldShow
    */
-  isVisible: true,
+  shouldShow: true,
 
   loaderClassNames: computed('classNames', function() {
     return 'infinity-loader '.concat(this.classNames).trim();
@@ -186,7 +186,7 @@ const InfinityLoaderComponent = Component.extend({
         set(infinityModel, '_scrollable', get(this, 'scrollable'));
         set(this, 'isDoneLoading', false);
         if (!get(this, 'hideOnInfinity')) {
-          set(this, 'isVisible', true);
+          set(this, 'shouldShow', true);
         }
         this._loadStatusDidChange();
       });
@@ -206,10 +206,10 @@ const InfinityLoaderComponent = Component.extend({
           set(this, 'isDoneLoading', true);
 
           if (get(this, 'hideOnInfinity')) {
-            set(this, 'isVisible', false);
+            set(this, 'shouldShow', false);
           }
         } else {
-          set(this, 'isVisible', true);
+          set(this, 'shouldShow', true);
         }
       });
   },

--- a/addon/templates/components/infinity-loader.hbs
+++ b/addon/templates/components/infinity-loader.hbs
@@ -1,4 +1,4 @@
-{{#if this.isVisible}}
+{{#if this.shouldShow}}
   <div
     {{did-insert this.didInsertLoader this}}
     class="{{this.loaderClassNames}}{{if this.viewportEntered " in-viewport"}}{{if this.isDoneLoading " reached-infinity"}}"


### PR DESCRIPTION
This fixes the [`isVisible`](https://deprecations.emberjs.com/v3.x/#toc_ember-component-is-visible) deprecation.

I know https://github.com/ember-infinity/ember-infinity/pull/416 was supposed to get rid of this deprecation but I'm still getting it in Ember 3.28.